### PR TITLE
スクロール位置を調整

### DIFF
--- a/src/lib/components/element/ScrollTo.svelte
+++ b/src/lib/components/element/ScrollTo.svelte
@@ -9,6 +9,6 @@
   };
 </script>
 
-<div on:click={scroll} class="cursor-pointer">
+<button on:click={scroll} class="cursor-pointer">
   <slot />
-</div>
+</button>

--- a/src/lib/components/element/SectionName.svelte
+++ b/src/lib/components/element/SectionName.svelte
@@ -1,3 +1,3 @@
-<h3 class="text-3xl pt-10 text-center">
+<h3 class="text-3xl pt-30 text-center scroll-mt-28">
   <slot />
 </h3>


### PR DESCRIPTION
close #450 


![image](https://user-images.githubusercontent.com/38714187/195739538-71793354-b181-40f9-9435-dcebf6e6f25f.png)
![image](https://user-images.githubusercontent.com/38714187/195739555-2e8e6229-c01f-48c9-a7a4-d518259e698f.png)




参考:https://www.bram.us/2020/03/01/prevent-content-from-being-hidden-underneath-a-fixed-header-by-using-scroll-margin-top/